### PR TITLE
Record coverage for each test under a separate "collection".

### DIFF
--- a/src/CodeCoverage/AbstractCodeCoverageReporter.php
+++ b/src/CodeCoverage/AbstractCodeCoverageReporter.php
@@ -2,9 +2,10 @@
 
 namespace Peridot\Reporter\CodeCoverage;
 
-use Peridot\Reporter\AbstractBaseReporter;
 use PHP_CodeCoverage;
 use PHP_CodeCoverage_Filter;
+use Peridot\Core\TestInterface;
+use Peridot\Reporter\AbstractBaseReporter;
 
 /**
  * Class AbstractCodeCoverageReporter
@@ -42,6 +43,8 @@ abstract class AbstractCodeCoverageReporter extends AbstractBaseReporter
 
         $this->eventEmitter->on('runner.start', [$this, 'onRunnerStart']);
         $this->eventEmitter->on('runner.end', [$this, 'onRunnerEnd']);
+        $this->eventEmitter->on('test.start', [$this, 'onTestStart']);
+        $this->eventEmitter->on('test.end', [$this, 'onTestEnd']);
     }
 
     /**
@@ -139,7 +142,6 @@ abstract class AbstractCodeCoverageReporter extends AbstractBaseReporter
      */
     public function onRunnerEnd()
     {
-        $this->coverage->stop();
         $this->footer();
 
         $this->output->write('Generating code coverage report... ');
@@ -157,7 +159,22 @@ abstract class AbstractCodeCoverageReporter extends AbstractBaseReporter
     public function onRunnerStart()
     {
         $this->eventEmitter->emit('code-coverage.start', [$this]);
-        $this->coverage->start('code-coverage');
+    }
+
+    /**
+     * Handle the test.start event.
+     */
+    public function onTestStart(TestInterface $test)
+    {
+        $this->coverage->start($test->getTitle());
+    }
+
+    /**
+     * Handle the test.end event.
+     */
+    public function onTestEnd()
+    {
+        $this->coverage->stop();
     }
 
     /**


### PR DESCRIPTION
This allows the user to see which specific tests actually executed a given line by hovering the mouse cursor over the line number, as in this screenshot:

<img width="897" alt="screen shot 2016-03-10 at 5 44 57 pm" src="https://cloud.githubusercontent.com/assets/761536/13662653/e4bd4b02-e6e7-11e5-88b5-fd4d3acbb11e.png">

I apologise for not adding any tests along with this PR, but I couldn't see an easy way to verify the intended behaviour as the `PHP_CodeCoverage` object is constructed internally I could not inject a mock. Please let me know if there's a way you'd prefer this to be done and I will add tests.