### PR TITLE
Close coverage collection for pending tests.

### DIFF
--- a/src/CodeCoverage/AbstractCodeCoverageReporter.php
+++ b/src/CodeCoverage/AbstractCodeCoverageReporter.php
@@ -45,6 +45,7 @@ abstract class AbstractCodeCoverageReporter extends AbstractBaseReporter
         $this->eventEmitter->on('runner.end', [$this, 'onRunnerEnd']);
         $this->eventEmitter->on('test.start', [$this, 'onTestStart']);
         $this->eventEmitter->on('test.end', [$this, 'onTestEnd']);
+        $this->eventEmitter->on('test.pending', [$this, 'onTestEnd']);
     }
 
     /**


### PR DESCRIPTION
Apologies for making more noise on a deprecated project, but I introduced a bug with that last PR - coverage collection wasn't stopped when a test was pending, essentially a memory leak.