### PR TITLE
Actually display text-coverage-report

### DIFF
--- a/src/CodeCoverage/AbstractCodeCoverageReporter.php
+++ b/src/CodeCoverage/AbstractCodeCoverageReporter.php
@@ -147,11 +147,11 @@ abstract class AbstractCodeCoverageReporter extends AbstractBaseReporter
 
         $this->output->write('Generating code coverage report... ');
 
-        $this->getCoverageReporter()->process($this->coverage, $this->getReportPath());
+        $output = $this->getCoverageReporter()->process($this->coverage, $this->getReportPath());
         $this->eventEmitter->emit('code-coverage.end', [$this]);
 
-        $this->output->write('Done!');
-        $this->output->writeln('');
+        $this->output->writeln('Done!');
+        $this->output->writeln($output);
     }
 
     /**


### PR DESCRIPTION
If the reporter generates output instead of files, like PHP_CodeCoverage_Report_Text, display it.
