### PR TITLE
Loosened constraint to allow PHP code coverage 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,28 @@
 language: php
 
-php:
-  - 5.6
-  - 5.5
-  - 5.4
-  - hhvm
-  - hhvm-nightly
+matrix:
+    include:
+        - php: 5.4
+        - php: 5.5
+        - php: 5.6
+        - php: 7.0
+        - php: 7.1
+        - php: nightly
+    fast_finish: true
+    allow_failures:
+        - php: nightly
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer
 
 install:
-    - composer install --prefer-source
+  - composer install --prefer-source
 
-script: vendor/bin/peridot specs/
+script:
+  - make travis
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - php: hhvm
-    - php: hhvm-nightly
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+test:
+	phpdbg --version
+	phpdbg -qrr vendor/bin/peridot specs
+
+coverage:
+	phpdbg --version
+	phpdbg -qrr -d memory_limit=512M vendor/bin/peridot --reporter html-code-coverage specs
+
+open-coverage:
+	open code-coverage-report/index.html
+
+travis:
+ifeq ($(TRAVIS_PHP_VERSION), nightly)
+	phpdbg --version
+	phpdbg -qrr vendor/bin/peridot specs
+else
+ifeq ($(TRAVIS_PHP_VERSION), $(filter $(TRAVIS_PHP_VERSION), 7.0 7.1))
+	phpdbg --version
+	phpdbg -qrr -d memory_limit=512M vendor/bin/peridot --reporter clover-code-coverage specs
+else
+	php --version
+	vendor/bin/peridot --reporter clover-code-coverage specs
+endif
+endif
+
+.PHONY: test coverage open-coverage travis

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     }
   ],
   "require": {
-    "peridot-php/peridot": "~1.0",
-    "phpunit/php-code-coverage": "~2.0"
+    "peridot-php/peridot": "^1",
+    "phpunit/php-code-coverage": "^2|^3"
   },
   "autoload": {
     "psr-4": {
-      "Peridot\\Reporter\\": "src/"
+      "Peridot\\Reporter\\": "src"
     }
   }
 }

--- a/peridot.php
+++ b/peridot.php
@@ -17,6 +17,6 @@ return function (EventEmitterInterface $eventEmitter) {
     });
 
     $eventEmitter->on('code-coverage.start', function (AbstractCodeCoverageReporter $reporter) {
-        $reporter->addDirectoryToWhitelist(__DIR__ . '/src')->addDirectoryToWhitelist(__DIR__ . '/specs');
+        $reporter->addDirectoryToWhitelist(__DIR__ . '/src');
     });
 };

--- a/src/CodeCoverage/HTMLCodeCoverageReporter.php
+++ b/src/CodeCoverage/HTMLCodeCoverageReporter.php
@@ -3,6 +3,7 @@
 namespace Peridot\Reporter\CodeCoverage;
 
 use PHP_CodeCoverage_Report_HTML;
+use Peridot\Console\Version;
 
 /**
  * Class HTMLCodeCoverageReporter
@@ -22,6 +23,13 @@ class HTMLCodeCoverageReporter extends AbstractCodeCoverageReporter
      */
     protected function createCoverageReporter()
     {
-        return new PHP_CodeCoverage_Report_HTML();
+        $name = Version::NAME;
+        $version = Version::NUMBER;
+
+        return new PHP_CodeCoverage_Report_HTML(
+            50,
+            90,
+            " and <a href=\"http://peridot-php.github.io/\">$name $version</a>"
+        );
     }
 }


### PR DESCRIPTION
This PR does two things:

- Updates the PHP Code Coverage constraint to allow version 3, which seems to work fine with the current codebase.
- Adds a link to the Peridot website to the bottom of the HTML code coverage report, similar to the link shown when generating coverage reports under PHPUnit.

Note that PHP Code Coverage version 4 already exists, but it has moved to namespaces, and so this library will require extensive refactoring before it will be compatible.